### PR TITLE
Changed the data-appendToBody attribute to data-append-to-body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.0.63] - 2018-03-12
+
+### Fixed
+- Changed the `data-appendToBody` attribute to `data-append-to-body` in order to be conform with the [HTML specification](https://www.w3.org/TR/2011/WD-html5-20110525/elements.html#embedding-custom-non-visible-data-with-the-data-attributes) (no uppercase letters).
+
 ## [1.0.62] - 2018-03-01
 
 ### Fixed

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -120,8 +120,8 @@
                 this.$valueField = this.options.valueField;
             }
 
-            if (this.$input.data('appendToBody')) {
-                this.options.appendToBody = !!this.$input.data('appendToBody');
+            if (this.$input.data('append-to-body')) {
+                this.options.appendToBody = !!this.$input.data('append-to-body');
             }
             if (this.options.appendToBody) {
                 let id = '' + (10000 * Math.random() * new Date().getTime() * window.outerHeight);


### PR DESCRIPTION
Changed the `data-appendToBody` attribute to `data-append-to-body` in order to be conform with the HTML specification.

The specification says that an attribute must not contain capital letters:
> and contains no characters in the range U+0041 to U+005A (LATIN CAPITAL LETTER A to LATIN CAPITAL LETTER Z)

Having capital letters in the attribute name caused problems in some projects, where Razor rendered the attribute with lower case letters, no matter how the attribute was defined in the markup.

For further reference see: https://www.w3.org/TR/2011/WD-html5-20110525/elements.html#embedding-custom-non-visible-data-with-the-data-attributes